### PR TITLE
replace "PROPOSED" charter with "DRAFT" charter at this stage

### DIFF
--- a/2025/did-methods-wg.html
+++ b/2025/did-methods-wg.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 
-    <title>PROPOSED DID Methods Working Group Charter</title>
+    <title>DRAFT DID Methods Working Group Charter</title>
 
     <link rel="stylesheet" href="https://www.w3.org/2005/10/w3cdoc.css" type="text/css" media="screen">
     <link rel="stylesheet" type="text/css" href="https://www.w3.org/OldGuide/pubrules-style.css">
@@ -72,7 +72,7 @@
 
 
     <main>
-      <h1 id="title">PROPOSED DID Methods Working Group Charter</h1>
+      <h1 id="title">DRAFT DID Methods Working Group Charter</h1>
       <!-- delete PROPOSED after AC review completed -->
 
       <p class="mission">
@@ -90,7 +90,7 @@ Group</a>
 
       <!-- delete the GH link after AC review completed -->
       <p style="padding: 0.5ex; border: 1px solid green">
-This proposed charter is available on
+This draft charter is available on
 <a href="https://github.com/w3c/did-methods-wg-charter/">GitHub</a>. Feel free to raise
 <a href="https://github.com/w3c/did-methods-wg-charter/issues">issues</a></i>.
       </p>


### PR DESCRIPTION
Per the [charter template](https://github.com/w3c/did-methods-wg-charter/blob/main/charter-template.html), DRAFT and PROPOSED indicate different charter statuses. A charter is initially in 'DRAFT' status, after which we:
* replace DRAFT with PROPOSED when the AC review starts
* delete PROPOSED after AC review completed