### PR TITLE
Fix the link to the DID Working Group

### DIFF
--- a/2025/did-methods-wg.html
+++ b/2025/did-methods-wg.html
@@ -394,7 +394,7 @@ review groups when major changes occur in a specification following a review.
           <h3 id="w3c-coordination">W3C Groups</h3>
           <dl>
             <dt>
-<a href="https://www.w3.org/2019/did-wg/">
+<a href="https://www.w3.org/groups/wg/did/">
 Decentralized Identifier Working Group</a>
             </dt>
             <dd>


### PR DESCRIPTION
The old link says, "This is the old homepage of the DID Working Group. It is not maintained anymore. The new homepage lives at https://www.w3.org/groups/wg/did/."